### PR TITLE
handle copy.copy() correctly

### DIFF
--- a/tests/test_tribool.py
+++ b/tests/test_tribool.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import copy
 import nose
 from nose.tools import raises
 
@@ -122,6 +123,16 @@ def test_str():
     assert str(Tribool(True)) == 'True'
     assert str(Tribool(False)) == 'False'
     assert str(Tribool(None)) == 'Indeterminate'
+
+def test_copy():
+    for value in (True, False, None):
+        for other in (True, False, None):
+            if value != other:
+                tri_copy = copy.copy(Tribool(value))
+                tri_deepcopy = copy.deepcopy(Tribool(value))
+                assert tri_copy is Tribool(value)
+                assert tri_deepcopy is Tribool(value)
+                assert tri_copy is not Tribool(other)
 
 def test_check():
     for value in (True, False, None):

--- a/tribool.py
+++ b/tribool.py
@@ -145,6 +145,14 @@ class Tribool(object):
         """String representation of Tribool."""
         return 'Tribool({0})'.format(str(self._value))
 
+    def __copy__(self):
+        """Value of copy.copy()."""
+        return self
+
+    def __deepcopy__(self, memo):
+        """Value of copy.deepcopy()."""
+        return self
+
     def _check(self):
         """Check invariant of Tribool."""
         assert (self._value in (True, False, None))


### PR DESCRIPTION
Identical Tribool values should always be identical instances.  This fixes the issue where copy.copy() creates different instances.
