### PR TITLE
added floor and ceiling support

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -111,7 +111,7 @@ For this reason, you cannot directly use a Tribool in an `if` statement::
     ...
   ValueError: Cannot implicitly convert Tribool to bool ...
 
-You can constrain Tribools to bool values using the `math.ceil` and `math.floor` functions (mapping `None` to `True` and `False`, respectively)::
+In python 3, you can constrain Tribools to bool values using the `math.ceil` and `math.floor` functions (mapping `None` to `True` and `False`, respectively)::
 
   >>> from math import ceil
   >>> if ceil(Tribool(None)): print("not definitely False")

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -111,6 +111,12 @@ For this reason, you cannot directly use a Tribool in an `if` statement::
     ...
   ValueError: Cannot implicitly convert Tribool to bool ...
 
+You can constrain Tribools to bool values using the `math.ceil` and `math.floor` functions (mapping `None` to `True` and `False`, respectively)::
+
+  >>> from math import ceil
+  >>> if ceil(Tribool(None)): print("not definitely False")
+  not definitely False
+
 To test the value of a Tribool, use the `value` property::
 
   >>> print Tribool(True).value, Tribool(False).value, Tribool(None).value

--- a/tests/test_tribool.py
+++ b/tests/test_tribool.py
@@ -3,6 +3,7 @@
 import copy
 import pickle
 from math import ceil, floor
+import sys
 
 import nose
 from nose.tools import raises
@@ -158,19 +159,20 @@ def test_check():
     for value in (True, False, None):
         Tribool(value)._check()
 
-def test_ceil():
-    Yes, No, Maybe = map(Tribool, (True, False, None))
+if sys.version_info[0] >= 3:
+    def test_ceil():
+        Yes, No, Maybe = map(Tribool, (True, False, None))
 
-    assert ceil(Yes)
-    assert ceil(Maybe)
-    assert not ceil(No)
+        assert ceil(Yes)
+        assert ceil(Maybe)
+        assert not ceil(No)
 
-def test_floor():
-    Yes, No, Maybe = map(Tribool, (True, False, None))
+    def test_floor():
+        Yes, No, Maybe = map(Tribool, (True, False, None))
 
-    assert floor(Yes)
-    assert not floor(Maybe)
-    assert not floor(No)
+        assert floor(Yes)
+        assert not floor(Maybe)
+        assert not floor(No)
 
 if __name__ == '__main__':
     nose.run()

--- a/tests/test_tribool.py
+++ b/tests/test_tribool.py
@@ -2,6 +2,7 @@
 
 import copy
 import pickle
+from math import ceil, floor
 
 import nose
 from nose.tools import raises
@@ -156,6 +157,20 @@ def test_repr():
 def test_check():
     for value in (True, False, None):
         Tribool(value)._check()
+
+def test_ceil():
+    Yes, No, Maybe = map(Tribool, (True, False, None))
+
+    assert ceil(Yes)
+    assert ceil(Maybe)
+    assert not ceil(No)
+
+def test_floor():
+    Yes, No, Maybe = map(Tribool, (True, False, None))
+
+    assert floor(Yes)
+    assert not floor(Maybe)
+    assert not floor(No)
 
 if __name__ == '__main__':
     nose.run()

--- a/tribool.py
+++ b/tribool.py
@@ -112,9 +112,11 @@ class Tribool(tuple):
         return ~(self < that)
 
     def __ceil__(self):
+        "Constrain the value to a bool, mapping Indeterminate to True"
         return self.value is not False
 
     def __floor__(self):
+        "Constrain the value to a bool, mapping Indeterminate to False"
         return self.value is True
 
     def __hash__(self):
@@ -132,8 +134,7 @@ class Tribool(tuple):
 
         """
         raise TypeError('Cannot convert Tribool to bool'
-                        ' (use the bitwise (&, |, ^, ~) operators,'
-                        ' use math.ceil or math.floor,'
+                        ' (use the bitwise (&, |, ^, ~) operators'
                         ' or convert result and use Tribool(...).value)')
 
     __bool__ = __nonzero__

--- a/tribool.py
+++ b/tribool.py
@@ -111,6 +111,12 @@ class Tribool(tuple):
         "Logical greater than or equal of Tribool and `that`."
         return ~(self < that)
 
+    def __ceil__(self):
+        return self.value is not False
+
+    def __floor__(self):
+        return self.value is True
+
     def __hash__(self):
         "Hash of Tribool."
         return id(self)
@@ -126,7 +132,8 @@ class Tribool(tuple):
 
         """
         raise TypeError('Cannot convert Tribool to bool'
-                        ' (use the bitwise (&, |, ^, ~) operators'
+                        ' (use the bitwise (&, |, ^, ~) operators,'
+                        ' use math.ceil or math.floor,'
                         ' or convert result and use Tribool(...).value)')
 
     __bool__ = __nonzero__


### PR DESCRIPTION
Often when using 3-value logic, I find it expedient to constrain a Tribool to a bool by "rounding" an Indeterminate to either a True or a False, depending on the situation. This usage is analogous to "rounding" the Tribool, either up or down to specify the rounded value of the Indeterminate. I added support for Trilean to be rounded in this way using `math.floor` or `math.ceil`.